### PR TITLE
v0.1.6 with `alsa` dependency added

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf alsa
 
       - name: install frontend dependencies
         run: npm install


### PR DESCRIPTION
Forgot an ubuntu dependency required by `cpal` for Vector's audio recording, don't mind me.